### PR TITLE
Fixed problem with split view not scrolling

### DIFF
--- a/SplitView.py
+++ b/SplitView.py
@@ -124,14 +124,14 @@ class SplitView:
 
             # Create a scrolled window for the left / top side.
             sw1 = Gtk.ScrolledWindow()
-            sw1.add_with_viewport(old_view)
+            sw1.add(old_view)
 
             # Set up a new View object
             new_view = Gedit.View.new(current_document)
 
             # Second scrolled window.
             sw2 = Gtk.ScrolledWindow()
-            sw2.add_with_viewport(new_view)
+            sw2.add(new_view)
 
             # Add the two scrolled windows to our Paned object.
             self.split_views[current_tab].add1(sw1)


### PR DESCRIPTION
As mentioned in Issue #4, the bottom window of the split view does not scroll in response to keyboard commands.

As it turns out this is because the view is added to a GtkScrolledWindow using add_with_viewport(). This is wrong. If the child element has native scrolling (which is the case here), it should be added with add().

This documentation ("http://www.pygtk.org/docs/pygtk/class-gtkscrolledwindow.html#method-gtkscrolledwindow--add-with-viewport") supports my conclusion, as does the fact that it resolves Issue #4... at least in Gedit 3.6.2.
