### PR TITLE
Change Loader to python3

### DIFF
--- a/SplitView.plugin
+++ b/SplitView.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=SplitView
 IAge=3
 Name=Split View


### PR DESCRIPTION
https://mail.gnome.org/archives/gedit-list/2012-November/msg00001.html

```
From: Ignacio Casal Quinteiro <nacho resa gmail com>
To: gedit-list <gedit-list gnome org>
Subject: [gedit-list] gedit ported to python 3
Date: Mon, 5 Nov 2012 22:58:12 +0100
```

Hey all,

just to let you know. We have ported gedit to python 3,
so probably if you had some plugin written in python it
will need to be ported to python 3 for the next major release 3.8.

Regards.
## 

Ignacio Casal Quinteiro
